### PR TITLE
No longer offer info@kbu.freifunk.net as contact address

### DIFF
--- a/_i18n/de/index/kontakt.html
+++ b/_i18n/de/index/kontakt.html
@@ -1,7 +1,7 @@
 <h2>Kontakt</h2>
 <div class="row">
 	<h3>Forum / Mailingliste</h3>
-	<p>Allgemeine oder technische Fragen diskutieren wir auf unserer Mailingliste. Trag Dich ein um an der Diskussion
+	<p>Wir diskutieren öffentlich auf unserer Mailingliste. Trag Dich ein um an der Diskussion
 	teilzunehmen. <br />
 	<fieldset>
 		<legend>Anmelden</legend>
@@ -16,13 +16,6 @@
 			</p>
 		</form>
 	</fieldset>
-	<h3>Anfragen</h3>
-	<p>Bei Anfragen kannst Du Dich gerne an <a href="mailto:info@kbu.freifunk.net">info@kbu.freifunk.net</a> wenden.<br />
-	Diese Adresse ist für allgemeine Projektanfragen (bspw. Presse) gedacht. Technische Probleme und Fragen zum Mitmachen sind auf unserer Mailingliste besser aufgehoben.
-	<br />
-	PGP Key: <a href="http://wwwkeys.pgp.net/pks/lookup?op=get&search=0xBA4BA40E8B398E0A" target="_blank">0xba4ba40e8b398e0a</a> - 
-	Fingerprint: <pre>B207 7C81 DA27 D063 D92E FC32 BA4B A40E 8B39 8E0A</pre></p>
-	</p>
 	<h3>IRC / Webchat</h3>
 	<p>
 	Du kannst mit uns auch chatten. Obwohl viele von uns online sind ("idle") kann es ein evtl. <b>mehrere Stunden dauern</b>, 

--- a/_i18n/en/index/kontakt.html
+++ b/_i18n/en/index/kontakt.html
@@ -1,7 +1,7 @@
 <h2>Contact</h2>
 <div class="row">
 	<h3>Forum / Mailing list</h3>
-	<p>We discuss general an technical things on our mailing list. Subscribe for joining the discussion.<br />
+	<p>We discuss all things on our mailing list. Subscribe for joining the discussion.<br />
 	<fieldset>
 		<legend>Subscribe</legend>
 		<form class="forms" action="http://lists.kbu.freifunk.net/cgi-bin/mailman/subscribe/freifunk-bonn" 
@@ -15,10 +15,6 @@
 			</p>
 		</form>
 	</fieldset>
-	<h3>Email contact</h3>
-	<p>Please contact <a href="mailto:info@kbu.frefiunk.net">info@kbu.freifunk.net</a> for questions, inquiries, etc. <br />
-	PGP Key: <a href="http://wwwkeys.pgp.net/pks/lookup?op=get&search=0xBA4BA40E8B398E0A" target="_blank">0xba4ba40e8b398e0a</a> - 
-	Fingerprint: <pre>B207 7C81 DA27 D063 D92E FC32 BA4B A40E 8B39 8E0A</pre></p>
 	<h3>IRC / Webchat</h3>
 	<p>
 	Chat with us. Although many of us are on-line continuously ("idle"), it may take <b>up to a few hours</b> until you get a reply.


### PR DESCRIPTION
info@kbu.freifunk.net nicht mehr als primäre-Kontaktadresse bewerben.
