### PR TITLE
Ort des Treffens in Bonn ändern und 2. Treffen in Bonn hinzufügen

### DIFF
--- a/_i18n/de/index/mitmachen.html
+++ b/_i18n/de/index/mitmachen.html
@@ -16,7 +16,7 @@
 			<h3>Werde Teil unserer Community</h3>
 			<p>Unsere regelmäßigen Treffen verteilen sich auf drei Donnerstage im Monat:</p>
 			<ul>
-				<li>1. Donnerstag im Monat: Treffen im <a target="_blank" href="http://netzladen.org/">Netzladen</a></li>
+				<li>1. Donnerstag im Monat: Treffen im <a target="_blank" href="http://www.ermekeilkarree.de/">Ermekeilkarree</a></li>
 				<li>2. Donnerstag: Treffen im <a target="_blank" href="http://koeln.ccc.de/">C4</a></li>
 				<li>3. Donnerstag: Entwicklertreffen im C4</li>
 			</ul>

--- a/_i18n/de/index/mitmachen.html
+++ b/_i18n/de/index/mitmachen.html
@@ -18,10 +18,10 @@
 			<ul>
 				<li>1. Donnerstag im Monat: Treffen im <a target="_blank" href="http://www.ermekeilkarree.de/">Ermekeilkarree</a></li>
 				<li>2. Donnerstag: Treffen im <a target="_blank" href="http://koeln.ccc.de/">C4</a></li>
-				<li>3. Donnerstag: Entwicklertreffen im C4</li>
 				<li>Letzter Dienstag im Monat: Treffen im Ermekeilkarree</li>
 			</ul>
-			<p>Interessenten sind zu allen Treffen gerne eingeladen, wobei zum kennenlernen die ersten beiden Termine die bessere Wahl sind, beim Entwickler-Treffen wird mehr gefachsimpelt.</p>
+			<p>Unregemäßig finden auch Entwicklertreffen im C4 statt.<p>
+			<p>Interessenten sind zu allen Treffen gerne eingeladen, wobei zum kennenlernen die regelmäßigen Termine die bessere Wahl sind, beim Entwickler-Treffen wird mehr gefachsimpelt.</p>
 			<p>Die Termine für die nächsten Treffen findest du <a href="{{ site.wikilink }}">im Wiki</a>. Außerdem werden die nächsten Treffen über <a href="http://lists.kbu.freifunk.net/cgi-bin/mailman/listinfo/freifunk-bonn">die Mailingliste</a> angekündigt.</p>
 			<p>Solltest du Fragen haben, kannst du diese auch gerne online stellen, Kontaktmöglichkeiten findest du unter <a href="#kontakt">Kontakt</a></p>
 		

--- a/_i18n/de/index/mitmachen.html
+++ b/_i18n/de/index/mitmachen.html
@@ -22,7 +22,7 @@
 			</ul>
 			<p>Unregemäßig finden auch Entwicklertreffen im C4 statt.<p>
 			<p>Interessenten sind zu allen Treffen gerne eingeladen, wobei zum kennenlernen die regelmäßigen Termine die bessere Wahl sind, beim Entwickler-Treffen wird mehr gefachsimpelt.</p>
-			<p>Die Termine für die nächsten Treffen findest du <a href="{{ site.wikilink }}">im Wiki</a>. Außerdem werden die nächsten Treffen über <a href="http://lists.kbu.freifunk.net/cgi-bin/mailman/listinfo/freifunk-bonn">die Mailingliste</a> angekündigt.</p>
+			<p>Die Termine für die nächsten Treffen findest du <a href="{{ site.wikilink }}">im Wiki</a>. Außerdem werden die nächsten Treffen in Bonn über <a href="http://lists.kbu.freifunk.net/cgi-bin/mailman/listinfo/freifunk-bonn">die Mailingliste</a> angekündigt.</p>
 			<p>Solltest du Fragen haben, kannst du diese auch gerne online stellen, Kontaktmöglichkeiten findest du unter <a href="#kontakt">Kontakt</a></p>
 		
 		</div>

--- a/_i18n/de/index/mitmachen.html
+++ b/_i18n/de/index/mitmachen.html
@@ -19,6 +19,7 @@
 				<li>1. Donnerstag im Monat: Treffen im <a target="_blank" href="http://www.ermekeilkarree.de/">Ermekeilkarree</a></li>
 				<li>2. Donnerstag: Treffen im <a target="_blank" href="http://koeln.ccc.de/">C4</a></li>
 				<li>3. Donnerstag: Entwicklertreffen im C4</li>
+				<li>Letzter Dienstag im Monat: Treffen im Ermekeilkarree</li>
 			</ul>
 			<p>Interessenten sind zu allen Treffen gerne eingeladen, wobei zum kennenlernen die ersten beiden Termine die bessere Wahl sind, beim Entwickler-Treffen wird mehr gefachsimpelt.</p>
 			<p>Die Termine für die nächsten Treffen findest du <a href="{{ site.wikilink }}">im Wiki</a>. Außerdem werden die nächsten Treffen über <a href="http://lists.kbu.freifunk.net/cgi-bin/mailman/listinfo/freifunk-bonn">die Mailingliste</a> angekündigt.</p>

--- a/_i18n/en/index/mitmachen.html
+++ b/_i18n/en/index/mitmachen.html
@@ -20,12 +20,12 @@
 			<ul>
 				<li>1st Thursday: <a target="_blank" href="http://www.ermekeilkarree.de/">Ermekeilkarree</a>, Bonn</li>
 				<li>2nd Thursday: <a target="_blank" href="http://koeln.ccc.de/">C4</a>, Cologne</li>
-				<li>3rd Thursday: Dev-Guys meetup at C4</li>
 				<li>Last Tuesday: Ermekeilkarree</li>
 			</ul>
+	                <p>There is also a irregular Dev-Guys meetup at C4</p>
 			<p>Everybode is welcome to join our meetings. Please note, that noobs will have a tough time at the Dev-Guys meetup.
 			</p>
-			<p>Dates are announced in the <a href="{{ site.wikilink }}">Wiki</a> and on the <a href="http://lists.kbu.freifunk.net/cgi-bin/mailman/listinfo/freifunk-bonn">mailingliste</a>, too</p>
+			<p>Dates are announced in the <a href="{{ site.wikilink }}">Wiki</a> and for the Bonn meetups on the <a href="http://lists.kbu.freifunk.net/cgi-bin/mailman/listinfo/freifunk-bonn">mailingliste</a>, too</p>
 			<p>Don't hesitate to <a href="#kontakt">contact</a> us.</p>
 
 		</div>


### PR DESCRIPTION
Nachdem wir uns jetzt nicht mehr im Netzladen treffen, wurde als neuer Ort das Ermeikeilkarree ausgewählt, das uns für unsere Treffen von der Ermekeilinitiative zur Verfügung gestellt wird.

Außerdem gibt es seit einiger Zeit schon ein zweites Treffen, was bisher noch nicht auf der Startseite angegeben war.