### PR TITLE
Update sprockets in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     ref (1.0.5)
     safe_yaml (1.0.4)
     sass (3.2.5)
-    sprockets (2.12.3)
+    sprockets (2.12.5)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)


### PR DESCRIPTION
Because of the GitHub warning

> We found a potential security vulnerability in one of your dependencies.
> A dependency defined in Gemfile.lock has known security vulnerabilities and should be updated.

I've updated sprockets to 2.12.5 in Gemfile.lock