### PR TITLE
Aktualisiere Zeiten und Orte der Treffen, mit Link zu Karte

### DIFF
--- a/_i18n/de/index/mitmachen.html
+++ b/_i18n/de/index/mitmachen.html
@@ -16,11 +16,11 @@
 			<h3>Werde Teil unserer Community</h3>
 			<p>Unsere regelmäßigen Treffen verteilen sich auf drei Donnerstage im Monat:</p>
 			<ul>
-				<li>1. Donnerstag im Monat: Treffen im <a target="_blank" href="http://www.ermekeilkarree.de/">Ermekeilkarree</a></li>
-				<li>2. Donnerstag: Treffen im <a target="_blank" href="http://koeln.ccc.de/">C4</a></li>
-				<li>4. Dienstag im Monat: Treffen im Ermekeilkarree</li>
+				<li>1. Donnerstag im Monat: Treffen in <a target="_blank" href="https://www.alte-vhs.de/">der alten VHS</a> in Bonn (<a target="_blank" href="https://www.openstreetmap.org/way/123890490">Karte</a>)</li>
+				<li>2. Donnerstag: Treffen im <a target="_blank" href="http://koeln.ccc.de/">C4</a> in Köln (<a target="_blank" href="https://www.openstreetmap.org/way/338873045">Karte</a>)</li>
+				<li>3. Donnerstag im Monat: Treffen in der alten VHS in Bonn</li>
 			</ul>
-			<p>Unregemäßig finden auch Entwicklertreffen im C4 statt.<p>
+			<p>Unregemäßig finden auch Entwicklertreffen im C4 in Köln statt.<p>
 			<p>Interessenten sind zu allen Treffen gerne eingeladen, wobei zum kennenlernen die regelmäßigen Termine die bessere Wahl sind, beim Entwickler-Treffen wird mehr gefachsimpelt.</p>
 			<p>Die Termine für die nächsten Treffen findest du <a href="{{ site.wikilink }}">im Wiki</a>. Außerdem werden die nächsten Treffen in Bonn über <a href="http://lists.kbu.freifunk.net/cgi-bin/mailman/listinfo/freifunk-bonn">die Mailingliste</a> angekündigt.</p>
 			<p>Solltest du Fragen haben, kannst du diese auch gerne online stellen, Kontaktmöglichkeiten findest du unter <a href="#kontakt">Kontakt</a></p>

--- a/_i18n/en/index/mitmachen.html
+++ b/_i18n/en/index/mitmachen.html
@@ -18,11 +18,11 @@
 			<h3> Be part of the community</h3>
 			<p>We have regular meetings on a monthly basis. Just step by or write us a mail.</p>
 			<ul>
-				<li>1st Thursday: <a target="_blank" href="http://www.ermekeilkarree.de/">Ermekeilkarree</a>, Bonn</li>
-				<li>2nd Thursday: <a target="_blank" href="http://koeln.ccc.de/">C4</a>, Cologne</li>
-				<li>4th Tuesday: Ermekeilkarree</li>
+				<li>1st Thursday: Meeting at <a target="_blank" href="https://www.alte-vhs.de/">“alte VHS”</a> in Bonn (<a target="_blank" href="https://www.openstreetmap.org/way/123890490">map</a>)</li>
+				<li>2nd Thursday: Meeting at <a target="_blank" href="http://koeln.ccc.de/">C4</a> in Cologne (<a target="_blank" href="https://www.openstreetmap.org/way/338873045">map</a>)</li>
+				<li>3rd Thursday: Meeting at the “alte VHS” in Bonn</li>
 			</ul>
-	                <p>There is also a irregular Dev-Guys meetup at C4</p>
+			<p>There is also a irregular Dev-Guys meetup at C4, Cologne.</p>
 			<p>Everybode is welcome to join our meetings. Please note, that noobs will have a tough time at the Dev-Guys meetup.
 			</p>
 			<p>Dates are announced in the <a href="{{ site.wikilink }}">Wiki</a> and for the Bonn meetups on the <a href="http://lists.kbu.freifunk.net/cgi-bin/mailman/listinfo/freifunk-bonn">mailingliste</a>, too</p>


### PR DESCRIPTION
Dieser PR enthält die Hinweise auf die Treffen an der alten VHS in Bonn und entfernt die Hinweise auf das Ermekeilkarree.